### PR TITLE
feat: restrict initialization to claude.ai domain

### DIFF
--- a/src/content.tsx
+++ b/src/content.tsx
@@ -1,9 +1,17 @@
-import { initialize } from "./providers/claude/template-injector";
+import { initializeClaude } from "./providers/claude/template-injector";
+
+const isClaude = () => window.location.hostname.endsWith("claude.ai");
+
+const initializeIfClaude = () => {
+  if (isClaude()) {
+    initializeClaude();
+  }
+};
 
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", initialize);
+  document.addEventListener("DOMContentLoaded", initializeIfClaude);
 } else {
-  initialize();
+  initializeIfClaude();
 }
 
 let lastUrl = location.href;
@@ -11,6 +19,6 @@ new MutationObserver(() => {
   const url = location.href;
   if (url !== lastUrl) {
     lastUrl = url;
-    initialize();
+    initializeIfClaude();
   }
 }).observe(document, { subtree: true, childList: true });

--- a/src/providers/claude/template-injector.ts
+++ b/src/providers/claude/template-injector.ts
@@ -106,7 +106,7 @@ const initializeTemplateButton = async () => {
   );
 };
 
-export const initialize = async () => {
+export const initializeClaude = async () => {
   try {
     await waitForElement('[data-testid="style-selector-dropdown"]');
     await sleep(500);


### PR DESCRIPTION
## Changes
- Add domain check to only initialize template injection on claude.ai
- Rename initialize function to `initializeClaude` for better clarity
- Keep URL change monitoring with added domain check

## Why
- Improves performance by preventing unnecessary initialization on non-Claude pages
- Makes the code more explicit about its purpose and target domain
- Follows security best practices by limiting content script execution scope
